### PR TITLE
analysis/cdecl: custom parser for a large enough subset of C's declaration syntax.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Install Vulkan loader
         run: sudo apt-get install libvulkan-dev
       - uses: actions/checkout@v4
+      - name: Checkout submodule
+        # Manually update submodules with --checkout because they are configured with update=none and will be skipped otherwise
+        run: git submodule update --recursive --init --force --checkout
       - name: Test all targets
         run: cargo test --workspace --all-targets
       - name: Test docs

--- a/analysis/Cargo.toml
+++ b/analysis/Cargo.toml
@@ -4,3 +4,5 @@ version = "2.0.0"
 edition = "2021"
 
 [dependencies]
+roxmltree = "0.19"
+tracing = "0.1"

--- a/analysis/src/cdecl.rs
+++ b/analysis/src/cdecl.rs
@@ -1,0 +1,393 @@
+use std::num::NonZeroU8;
+
+/// Identifier-category-aware minimal tokenization of a subset of C syntax,
+/// sufficient for parsing the C declarations used in `vk.xml`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum CTok<'a> {
+    /// Identifier referring to a type declaration in scope.
+    TypeName(&'a str),
+
+    /// Identifier referring to a value declaration in scope.
+    ValueName(&'a str),
+
+    /// Identifier that is being presently declared (exactly one per `CDecl`).
+    DeclName(&'a str),
+
+    /// Supported keyword (one of [`CTok::SUPPORTED_KEYWORDS`]).
+    Kw(&'static str),
+
+    /// Any ASCII punctuation (i.e. as determined by [`char::is_ascii_punctuation`]).
+    // FIXME(eddyb) this could really use the `std::ascii` API.
+    Punct(char),
+
+    /// Integer literal (for e.g. array lengths).
+    IntLit(&'a str),
+
+    /// Unknown identifier (all known cases are spec bugs or deficiencies).
+    StrayIdent(&'a str),
+}
+
+#[derive(Debug)]
+pub struct UnsupportedCTok<'a>(&'a str);
+
+impl<'a> CTok<'a> {
+    pub const SUPPORTED_KEYWORDS: &'static [&'static str] = &["const", "struct", "typedef", "void"];
+
+    pub fn lex_into(
+        s: &'a str,
+        out: &mut impl Extend<CTok<'a>>,
+    ) -> Result<(), UnsupportedCTok<'a>> {
+        // FIXME(eddyb) this could really use the `std::ascii` API.
+        let mut s = s;
+        while let Some(c) = s.chars().next() {
+            if !c.is_ascii() {
+                return Err(UnsupportedCTok(s));
+            }
+
+            let is_ident_or_number = |c: char| c.is_ascii_alphanumeric() || c == '_';
+            let tok = if is_ident_or_number(c) {
+                let len = s.chars().take_while(|&c| is_ident_or_number(c)).count();
+                let (tok, rest) = s.split_at(len);
+                s = rest;
+                if c.is_ascii_digit() {
+                    CTok::IntLit(tok)
+                } else if let Some(kw) = CTok::SUPPORTED_KEYWORDS.iter().find(|&&kw| kw == tok) {
+                    CTok::Kw(kw)
+                } else {
+                    CTok::StrayIdent(tok)
+                }
+            } else if c.is_ascii_punctuation() {
+                s = &s[1..];
+                CTok::Punct(c)
+            } else if c.is_ascii_whitespace() {
+                s = s.trim_start();
+                continue;
+            } else {
+                return Err(UnsupportedCTok(s));
+            };
+            out.extend([tok]);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct CDecl<'a> {
+    pub ty: CType<'a>,
+    pub name: &'a str,
+    pub bitfield_width: Option<NonZeroU8>,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum CDeclMode {
+    TypeDef,
+    StructMember,
+    FuncParam,
+    FuncTypeParam,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum CType<'a> {
+    Base(CBaseType<'a>),
+    Ptr {
+        implicit_for_decay: bool,
+        is_const: bool,
+        pointee: Box<CType<'a>>,
+    },
+    Array {
+        element: Box<CType<'a>>,
+        len: CArrayLen<'a>,
+    },
+    Func {
+        ret_ty: Option<Box<CType<'a>>>,
+        params: Vec<CDecl<'a>>,
+    },
+}
+
+impl CType<'_> {
+    pub const VOID: CType<'static> = CType::Base(CBaseType {
+        struct_tag: false,
+        name: "void",
+    });
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct CBaseType<'a> {
+    pub struct_tag: bool,
+    pub name: &'a str,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum CArrayLen<'a> {
+    Named(&'a str),
+    Literal(u128),
+}
+
+#[derive(Debug)]
+pub struct CDeclParseError<'a, 'b> {
+    pub kind: CDeclParseErrorKind<'a>,
+    pub tokens: &'b [CTok<'a>],
+}
+
+#[derive(Debug)]
+pub enum CDeclParseErrorKind<'a> {
+    Missing(&'static str),
+    Multiple(&'static str),
+    Unused(&'static str),
+    InvalidIntLit(std::num::ParseIntError),
+    UnsupportedLeftmostToken(CTok<'a>),
+    UnsupportedRightmostToken(CTok<'a>),
+    UnbalancedBrackets,
+    UnsupportedArrayLength,
+}
+
+impl<'a> CDecl<'a> {
+    // HACK(eddyb) this split is literally just to simplify error tracking.
+    pub fn parse<'b>(
+        mode: CDeclMode,
+        tokens: &'b [CTok<'a>],
+    ) -> Result<CDecl<'a>, CDeclParseError<'a, 'b>> {
+        CDecl::parse_inner(mode, tokens).map_err(|kind| CDeclParseError { kind, tokens })
+    }
+    fn parse_inner<'b>(
+        mode: CDeclMode,
+        tokens: &'b [CTok<'a>],
+    ) -> Result<CDecl<'a>, CDeclParseErrorKind<'a>> {
+        use CDeclParseErrorKind as ErrorKind;
+
+        trait InsertIfNone<T> {
+            fn insert_if_none(&mut self, value: T) -> Option<&mut T>;
+        }
+        impl<T> InsertIfNone<T> for Option<T> {
+            fn insert_if_none(&mut self, value: T) -> Option<&mut T> {
+                self.is_none().then(|| self.insert(value))
+            }
+        }
+
+        let (mut left, decl_name, mut right) = {
+            let mut decl_names =
+                tokens
+                    .iter()
+                    .copied()
+                    .enumerate()
+                    .filter_map(|(i, tok)| match tok {
+                        CTok::DeclName(name) => Some((i, name)),
+
+                        // HACK(eddyb) this is only allowed due to the (few)
+                        // function pointer typedefs in `vk.xml`, which don't
+                        // label parameter names in any special way.
+                        CTok::StrayIdent(name) if mode == CDeclMode::FuncTypeParam => {
+                            Some((i, name))
+                        }
+
+                        _ => None,
+                    });
+            match (decl_names.next(), decl_names.next()) {
+                (Some((i, name)), None) => (&tokens[..i], name, &tokens[i + 1..]),
+                (None, _) => return Err(ErrorKind::Missing("DeclName")),
+                (Some(_), Some(_)) => return Err(ErrorKind::Multiple("DeclName")),
+            }
+        };
+
+        if mode == CDeclMode::TypeDef {
+            // NOTE(eddyb) `typedef` can appear later on as well, so this is
+            // unnecessarily strict, but it avoids much more involved tracking.
+            left = left
+                .strip_prefix(&[CTok::Kw("typedef")])
+                .ok_or(ErrorKind::Missing("typedef"))?;
+            right = right
+                .strip_suffix(&[CTok::Punct(';')])
+                .ok_or(ErrorKind::Missing(";"))?;
+        }
+
+        let bitfield_width = match right {
+            [rest @ .., CTok::Punct(':'), CTok::IntLit(width_lit)]
+                if mode == CDeclMode::StructMember =>
+            {
+                right = rest;
+                Some(width_lit.parse().map_err(ErrorKind::InvalidIntLit)?)
+            }
+            _ => None,
+        };
+
+        // FIXME(eddyb) deduplicate qualifier parsing somehow.
+        let mut const_qualif = match left {
+            [CTok::Kw("const"), rest @ ..] => {
+                left = rest;
+                Some(())
+            }
+            _ => None,
+        };
+
+        let mut ty = CType::Base(match left {
+            [CTok::Kw("struct"), CTok::TypeName(name), rest @ ..] => {
+                left = rest;
+                CBaseType {
+                    struct_tag: true,
+                    name,
+                }
+            }
+            [CTok::TypeName(name) | CTok::Kw(name @ "void"), rest @ ..] => {
+                left = rest;
+                CBaseType {
+                    struct_tag: false,
+                    name,
+                }
+            }
+            _ => return Err(ErrorKind::Missing("TypeName")),
+        });
+
+        // This is the core of the C declaration parsing strategy: we have some
+        // type `T` (held in the variable `ty`) and tokens to either side of the
+        // name being declared, and at every step of the loops below there is a
+        // "closest binding" (postfix) "type operator", which we pattern-match
+        // from its side and then apply to `T`, replacing `T` with any of:
+        // - `T*` pointers (like Rust `*T`), from `T* ...`
+        //   (only `left` side "type operator", and it takes precedence, making
+        //    array-of-pointers much easier to spell out than pointer-to-array)
+        // - `T[N]` arrays (like Rust `[T; N]`), from `T ...[N]`
+        // - `T(A, B, C)` functions, from `T ...(A, B, C)`
+        //   (Rust only has pointers to such types, `fn(A, B, C) -> T`)
+        //
+        // Notably, both sides are consumed outside-in (`left` LTR, `right` RTL),
+        // converging on the middle (where the name being declared is), and that
+        // can get confusing (an older comment below also tried to explain it).
+        //
+        // Once we run out of "type operators", and the declaration isn't trivial,
+        // only syntax left is parenthesization *around* the name being declared,
+        // with everything inside the parentheses applying *on top of* everything
+        // outside: but we've consumed everything outside so we're actually left
+        // with `T (...)` and we can simply drop the parentheses!
+        while !left.is_empty() || !right.is_empty() {
+            while let Some((&leftmost, after_leftmost)) = left.split_first() {
+                match leftmost {
+                    CTok::Kw("const") => {
+                        const_qualif
+                            .insert_if_none(())
+                            .ok_or(ErrorKind::Multiple("const"))?;
+                    }
+                    CTok::Punct('*') => {
+                        ty = CType::Ptr {
+                            implicit_for_decay: false,
+                            is_const: const_qualif.take().is_some(),
+                            pointee: Box::new(ty),
+                        };
+                    }
+
+                    // Outermost parentheses around the name being declared,
+                    // handled together after both `left` and `right` loops.
+                    CTok::Punct('(') => break,
+
+                    _ => return Err(ErrorKind::UnsupportedLeftmostToken(leftmost)),
+                }
+                left = after_leftmost;
+            }
+            'right: while let Some(&rightmost) = right.last() {
+                // NOTE(eddyb) outermost (i.e. rightmost) suffixes apply first,
+                // and the only way this is "intuitive" is that e.g. a 2D array
+                // like `T m[A][B]` means `typeof(m[i][j]) = T`, and the lvalue
+                // syntax has to match the declaration (so `i < A` and `j < B`),
+                // IOW it's equivalent to `(T[B]) m[A]` / `typeof((m[i])[j]) = T`
+                // (if C had type parenthesization, or via C++ type aliases).
+                match rightmost {
+                    CTok::Punct(']' | ')') => {}
+
+                    _ => return Err(ErrorKind::UnsupportedRightmostToken(rightmost)),
+                }
+
+                // As `rightmost` is `]`/`)`, the matching `[`/`(` must be found.
+                let (before_rightmost_group, rightmost_group) = {
+                    let mut i = right.len() - 1;
+                    let mut nesting = 0;
+                    loop {
+                        let checked_dec =
+                            |x: usize| x.checked_sub(1).ok_or(ErrorKind::UnbalancedBrackets);
+                        match right[i] {
+                            CTok::Punct(']' | ')') => nesting += 1,
+                            CTok::Punct('[' | '(') => nesting = checked_dec(nesting)?,
+                            _ => {}
+                        }
+                        if nesting == 0 {
+                            break;
+                        }
+
+                        // Outermost parentheses around the name being declared,
+                        // handled together after both `left` and `right` loops.
+                        if i == 0 && rightmost == CTok::Punct(')') {
+                            break 'right;
+                        }
+
+                        i = checked_dec(i)?;
+                    }
+                    right.split_at(i)
+                };
+
+                match rightmost_group {
+                    [CTok::Punct('['), len @ .., CTok::Punct(']')] => {
+                        ty = CType::Array {
+                            element: Box::new(ty),
+                            len: match len {
+                                [CTok::ValueName(name)] => CArrayLen::Named(name),
+                                [CTok::IntLit(lit)] => CArrayLen::Literal(
+                                    lit.parse().map_err(ErrorKind::InvalidIntLit)?,
+                                ),
+                                _ => return Err(ErrorKind::UnsupportedArrayLength),
+                            },
+                        };
+                    }
+                    [CTok::Punct('('), params @ .., CTok::Punct(')')] => {
+                        if const_qualif.is_some() {
+                            return Err(ErrorKind::Unused("const"));
+                        }
+
+                        let params = match params {
+                            [] => return Err(ErrorKind::Missing("parameters")),
+                            [CTok::Kw("void")] => vec![],
+                            _ => params
+                                .split(|&tok| tok == CTok::Punct(','))
+                                .map(|param| CDecl::parse_inner(CDeclMode::FuncTypeParam, param))
+                                .collect::<Result<_, _>>()?,
+                        };
+                        ty = CType::Func {
+                            ret_ty: Some(ty).filter(|ty| *ty != CType::VOID).map(Box::new),
+                            params,
+                        };
+                    }
+                    _ => return Err(ErrorKind::UnbalancedBrackets),
+                }
+                right = before_rightmost_group;
+            }
+
+            // Outermost parentheses around the name being declared, handled here
+            // to ensure there is nothing else left around them, and can therefore
+            // be cleanly removed.
+            if let ([CTok::Punct('('), left_inner @ ..], [right_inner @ .., CTok::Punct(')')]) =
+                (left, right)
+            {
+                left = left_inner;
+                right = right_inner;
+            }
+        }
+
+        // NOTE(eddyb) parameters to functions decay "into" pointers, but because
+        // we control the typesystem, we can keep both the array types, and the
+        // implicit pointer, closer to Rust e.g. `&[T; N]` arguments.
+        if let (CDeclMode::FuncParam, CType::Array { .. }) = (mode, &ty) {
+            ty = CType::Ptr {
+                implicit_for_decay: true,
+                is_const: const_qualif.take().is_some(),
+                pointee: Box::new(ty),
+            };
+        }
+
+        if const_qualif.is_some() {
+            return Err(ErrorKind::Unused("const"));
+        }
+
+        Ok(CDecl {
+            ty,
+            name: decl_name,
+            bitfield_width,
+        })
+    }
+}

--- a/analysis/src/lib.rs
+++ b/analysis/src/lib.rs
@@ -18,6 +18,50 @@ impl Analysis {
             video: Library::new(vulkan_headers_path.join("registry/video.xml")),
         }
     }
+
+    pub fn dump_as_pseudo_rust(&self) {
+        for fp in &self.vk._xml.funcpointers {
+            eprintln!(
+                "type {} = {};",
+                fp.c_decl.name,
+                fp.c_decl.ty.to_pseudo_rust()
+            );
+        }
+        for st in &self.vk._xml.structs {
+            eprintln!("struct {} {{", st.name);
+            for m in &st.members {
+                if m.len.len() > 1 {}
+                let len = if !m.altlen.is_empty() {
+                    &m.altlen
+                } else {
+                    &m.len
+                };
+                eprint!("    {}", m.c_decl.to_pseudo_rust_with_external_lengths(len));
+                if let Some(val) = &m.values {
+                    eprint!(" = {val}");
+                }
+                eprintln!(",");
+            }
+            eprintln!("}}");
+        }
+        for cmd in &self.vk._xml.commands {
+            eprintln!("unsafe extern fn {}(", cmd.name);
+            for p in &cmd.params {
+                let len = if !p.altlen.is_empty() {
+                    &p.altlen
+                } else {
+                    &p.len
+                };
+                eprint!("    {}", p.c_decl.to_pseudo_rust_with_external_lengths(len));
+                eprintln!(",");
+            }
+            eprint!(")");
+            if let Some(ret_ty) = &cmd.return_type {
+                eprint!(" -> {}", ret_ty.to_pseudo_rust());
+            }
+            eprintln!(";");
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/analysis/src/lib.rs
+++ b/analysis/src/lib.rs
@@ -1,9 +1,38 @@
-use std::path::Path;
+mod xml;
 
-pub struct Analysis {}
+use std::{fs, path::Path};
+use tracing::{debug, error_span};
+
+#[derive(Debug)]
+pub struct Analysis {
+    pub vk: Library,
+    pub video: Library,
+}
 
 impl Analysis {
-    pub fn new(_vulkan_headers_path: impl AsRef<Path>) -> Analysis {
-        Analysis {}
+    pub fn new(vulkan_headers_path: impl AsRef<Path>) -> Analysis {
+        let vulkan_headers_path = vulkan_headers_path.as_ref();
+        Analysis {
+            vk: Library::new(vulkan_headers_path.join("registry/vk.xml")),
+            video: Library::new(vulkan_headers_path.join("registry/video.xml")),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Library {
+    _xml: xml::Registry,
+}
+
+impl Library {
+    fn new(xml_path: impl AsRef<Path>) -> Library {
+        let xml = error_span!("xml", path = %xml_path.as_ref().display()).in_scope(|| {
+            // We leak the input string here for convenience, to avoid explicit lifetimes.
+            let xml_input = Box::leak(fs::read_to_string(xml_path).unwrap().into_boxed_str());
+            debug!("parsing xml");
+            xml::Registry::parse(xml_input, "vulkan")
+        });
+
+        Library { _xml: xml }
     }
 }

--- a/analysis/src/lib.rs
+++ b/analysis/src/lib.rs
@@ -1,3 +1,4 @@
+mod cdecl;
 mod xml;
 
 use std::{fs, path::Path};

--- a/analysis/src/xml.rs
+++ b/analysis/src/xml.rs
@@ -1,0 +1,806 @@
+use roxmltree::StringStorage;
+use std::{borrow::Cow, fmt::Write};
+use tracing::{debug, info_span, trace};
+
+/// A node with its `'input` lifetime set to `'static`.
+type Node<'a> = roxmltree::Node<'a, 'static>;
+/// String type used for XML attribute and text values.
+///
+/// A `&'static str` is not used directly because sometimes string allocation is
+/// needed, for example when replacing `&quot;` with normal quotes.
+pub type XmlStr = Cow<'static, str>;
+
+pub trait UnwrapBorrowed<'a, B>
+where
+    B: ToOwned + ?Sized,
+{
+    fn unwrap_borrowed(&self) -> &'a B;
+}
+
+impl<'a, B> UnwrapBorrowed<'a, B> for Cow<'a, B>
+where
+    B: ToOwned + ?Sized,
+{
+    fn unwrap_borrowed(&self) -> &'a B {
+        match self {
+            Cow::Borrowed(b) => b,
+            Cow::Owned(_) => panic!("Called `unwrap_borrowed` on `Owned` value"),
+        }
+    }
+}
+
+/// Converts `roxmltree`'s `StringStorage` to a `XmlStr`
+fn make_xml_str(string_storage: StringStorage<'static>) -> XmlStr {
+    match string_storage {
+        StringStorage::Borrowed(s) => Cow::Borrowed(s),
+        StringStorage::Owned(s) => Cow::Owned((*s).into()),
+    }
+}
+
+/// Retrieves the value of the `node`'s attribute named `name`.
+fn attribute(node: Node, name: &str) -> Option<XmlStr> {
+    node.attribute_node(name)
+        .map(|attr| make_xml_str(attr.value_storage().clone()))
+}
+
+/// Retrieves the ','-separated values of the `node`'s attribute named `name`.
+fn attribute_comma_separated(node: Node, name: &str) -> Vec<&'static str> {
+    attribute(node, name)
+        .map(|value| value.unwrap_borrowed().split(',').collect())
+        .unwrap_or_default()
+}
+
+/// Retrieves the text inside the next child element of `node` named `name`.
+fn child_text(node: Node, name: &str) -> Option<XmlStr> {
+    let child = node.children().find(|node| node.has_tag_name(name));
+    child.map(|node| match node.text_storage().unwrap().clone() {
+        StringStorage::Borrowed(s) => Cow::Borrowed(s),
+        StringStorage::Owned(s) => Cow::Owned((*s).into()),
+    })
+}
+
+/// Retrieves the text of all of `node`'s descendants, concatenated.
+/// Anything within a `<comment>` element will be ignored.
+fn descendant_text(node: Node) -> String {
+    node.descendants()
+        .filter(Node::is_text)
+        // Ignore any text within a <comment> element.
+        .filter(|node| !node.ancestors().any(|node| node.has_tag_name("comment")))
+        .map(|node| node.text().unwrap())
+        .collect::<String>()
+}
+
+/// Returns [`true`] when the `node`'s "api" attribute matches the `expected` API.
+fn api_matches(node: &Node, expected: &str) -> bool {
+    node.attribute("api")
+        .map(|values| values.split(',').any(|value| value == expected))
+        .unwrap_or(true)
+}
+
+/// Returns a "pseudo-XML" representation of the node, for use in tracing spans.
+fn node_span_field(node: &Node) -> String {
+    let mut output = format!("<{:?}", node.tag_name());
+    for attr in node.attributes() {
+        write!(output, " {}='{}'", attr.name(), attr.value()).unwrap();
+    }
+
+    output + ">"
+}
+
+/// Raw representation of Vulkan XML files (`vk.xml`, `video.xml`).
+#[derive(Debug, Default)]
+pub struct Registry {
+    pub externals: Vec<External>,
+    pub basetypes: Vec<BaseType>,
+    pub bitmask_types: Vec<BitMaskType>,
+    pub bitmask_aliases: Vec<Alias>,
+    pub handles: Vec<Handle>,
+    pub handle_aliases: Vec<Alias>,
+    pub enum_types: Vec<EnumType>,
+    pub enum_aliases: Vec<Alias>,
+    pub funcpointers: Vec<FuncPointer>,
+    pub structs: Vec<Structure>,
+    pub struct_aliases: Vec<Alias>,
+    pub unions: Vec<Structure>,
+    pub constants: Vec<Constant>,
+    pub constant_aliases: Vec<Alias>,
+    pub enums: Vec<Enum>,
+    pub bitmasks: Vec<BitMask>,
+    pub commands: Vec<Command>,
+    pub command_aliases: Vec<Alias>,
+    pub features: Vec<Feature>,
+    pub extensions: Vec<Extension>,
+}
+
+impl Registry {
+    pub fn parse(input: &'static str, api: &str) -> Registry {
+        let doc = roxmltree::Document::parse(input).unwrap();
+        Registry::from_node(doc.root_element(), api)
+    }
+
+    fn from_node(registry_node: Node, api: &str) -> Registry {
+        let mut registry = Registry::default();
+        for registry_child in registry_node
+            .children()
+            .filter(|node| api_matches(node, api))
+        {
+            match registry_child.tag_name().name() {
+                "types" => {
+                    for type_node in registry_child
+                        .children()
+                        .filter(|node| node.has_tag_name("type"))
+                        .filter(|node| api_matches(node, api))
+                    {
+                        let _s = info_span!("type", node = node_span_field(&type_node)).entered();
+                        trace!("encountered node");
+                        if type_node.has_attribute("alias") {
+                            match type_node.attribute("category") {
+                                Some("bitmask") => {
+                                    registry.bitmask_aliases.push(Alias::from_node(type_node));
+                                }
+                                Some("handle") => {
+                                    registry.handle_aliases.push(Alias::from_node(type_node));
+                                }
+                                Some("enum") => {
+                                    registry.enum_aliases.push(Alias::from_node(type_node));
+                                }
+                                Some("struct") => {
+                                    registry.struct_aliases.push(Alias::from_node(type_node));
+                                }
+                                _ => debug!("ignored"),
+                            }
+                        } else {
+                            match type_node.attribute("category") {
+                                Some("basetype") => {
+                                    registry.basetypes.push(BaseType::from_node(type_node))
+                                }
+                                Some("bitmask") => registry
+                                    .bitmask_types
+                                    .push(BitMaskType::from_node(type_node)),
+                                Some("handle") => {
+                                    registry.handles.push(Handle::from_node(type_node))
+                                }
+                                Some("enum") => {
+                                    registry.enum_types.push(EnumType::from_node(type_node))
+                                }
+                                Some("funcpointer") => registry
+                                    .funcpointers
+                                    .push(FuncPointer::from_node(type_node)),
+                                Some("struct") => {
+                                    registry.structs.push(Structure::from_node(type_node, api))
+                                }
+                                Some("union") => {
+                                    registry.unions.push(Structure::from_node(type_node, api));
+                                }
+                                Some(_) => debug!("ignored"),
+                                None => {
+                                    registry.externals.push(External::from_node(type_node));
+                                }
+                            }
+                        }
+                    }
+                }
+                "enums" => {
+                    let _s = info_span!("enum", node = node_span_field(&registry_child)).entered();
+                    trace!("encountered node");
+                    match registry_child.attribute("type") {
+                        Some("enum") => registry.enums.push(Enum::from_node(registry_child, api)),
+                        Some("bitmask") => registry
+                            .bitmasks
+                            .push(BitMask::from_node(registry_child, api)),
+                        None if registry_child.attribute("name") == Some("API Constants") => {
+                            for enum_node in registry_child
+                                .children()
+                                .filter(|node| node.has_tag_name("enum"))
+                                .filter(|node| api_matches(node, api))
+                            {
+                                if enum_node.has_attribute("alias") {
+                                    registry.constant_aliases.push(Alias::from_node(enum_node));
+                                } else {
+                                    registry.constants.push(Constant::from_node(enum_node));
+                                }
+                            }
+                        }
+                        _ => debug!("ignored"),
+                    }
+                }
+                "commands" => {
+                    for command_node in registry_child
+                        .children()
+                        .filter(|node| node.has_tag_name("command"))
+                        .filter(|node| api_matches(node, api))
+                    {
+                        let _s =
+                            info_span!("command", node = node_span_field(&command_node)).entered();
+                        trace!("encountered node");
+                        if command_node.has_attribute("alias") {
+                            registry
+                                .command_aliases
+                                .push(Alias::from_node(command_node));
+                        } else {
+                            registry
+                                .commands
+                                .push(Command::from_node(command_node, api));
+                        }
+                    }
+                }
+                "feature" => {
+                    let _s =
+                        info_span!("feature", node = node_span_field(&registry_child)).entered();
+                    trace!("encountered node");
+                    registry
+                        .features
+                        .push(Feature::from_node(registry_child, api));
+                }
+                "extensions" => {
+                    for extension_node in registry_child
+                        .children()
+                        .filter(|node| node.has_tag_name("extension"))
+                        .filter(|node| {
+                            node.attribute("supported")
+                                .map(|values| values.split(',').any(|support| support == api))
+                                .unwrap_or(true)
+                        })
+                    {
+                        let _s = info_span!("extension", node = node_span_field(&extension_node))
+                            .entered();
+                        trace!("encountered node");
+                        registry
+                            .extensions
+                            .push(Extension::from_node(extension_node, api));
+                    }
+                }
+                _ => (),
+            }
+        }
+
+        registry
+    }
+}
+
+#[derive(Debug)]
+pub struct Alias {
+    pub name: XmlStr,
+    pub alias: XmlStr,
+}
+
+impl Alias {
+    fn from_node(node: Node) -> Alias {
+        Alias {
+            name: attribute(node, "name").unwrap(),
+            alias: attribute(node, "alias").unwrap(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct External {
+    pub name: XmlStr,
+    pub requires: Option<XmlStr>,
+}
+
+impl External {
+    fn from_node(node: Node) -> External {
+        External {
+            name: attribute(node, "name").unwrap(),
+            requires: attribute(node, "requires"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct BaseType {
+    pub name: XmlStr,
+    /// [`None`] indicates this being a platform-specific type.
+    pub ty: Option<XmlStr>,
+}
+
+impl BaseType {
+    fn from_node(node: Node) -> BaseType {
+        BaseType {
+            name: child_text(node, "name").unwrap(),
+            ty: child_text(node, "type").map(Into::into),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct BitMaskType {
+    pub requires: Option<XmlStr>,
+    pub bitvalues: Option<XmlStr>,
+    pub ty: XmlStr,
+    pub name: XmlStr,
+}
+
+impl BitMaskType {
+    fn from_node(node: Node) -> BitMaskType {
+        BitMaskType {
+            requires: attribute(node, "requires"),
+            bitvalues: attribute(node, "bitvalues"),
+            ty: child_text(node, "type").unwrap(),
+            name: child_text(node, "name").unwrap(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Handle {
+    pub parent: Option<XmlStr>,
+    pub objtypeenum: XmlStr,
+    pub ty: XmlStr,
+    pub name: XmlStr,
+}
+
+impl Handle {
+    fn from_node(node: Node) -> Handle {
+        Handle {
+            parent: attribute(node, "parent"),
+            objtypeenum: attribute(node, "objtypeenum").unwrap(),
+            ty: child_text(node, "type").unwrap(),
+            name: child_text(node, "name").unwrap(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct EnumType {
+    pub name: XmlStr,
+}
+
+impl EnumType {
+    fn from_node(node: Node) -> EnumType {
+        EnumType {
+            name: attribute(node, "name").unwrap(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct FuncPointer {
+    pub name: XmlStr,
+    pub c_declaration: String,
+    pub requires: Option<XmlStr>,
+}
+
+impl FuncPointer {
+    fn from_node(node: Node) -> FuncPointer {
+        FuncPointer {
+            name: child_text(node, "name").unwrap(),
+            c_declaration: descendant_text(node),
+            requires: attribute(node, "requires"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct StructureMember {
+    pub name: XmlStr,
+    pub c_declaration: String,
+    pub values: Option<XmlStr>,
+    pub len: Vec<&'static str>,
+    pub altlen: Option<XmlStr>,
+    pub optional: Vec<&'static str>,
+}
+
+impl StructureMember {
+    fn from_node(node: Node) -> StructureMember {
+        StructureMember {
+            name: child_text(node, "name").unwrap(),
+            c_declaration: descendant_text(node),
+            values: attribute(node, "values"),
+            len: attribute_comma_separated(node, "len"),
+            altlen: attribute(node, "altlen"),
+            optional: attribute_comma_separated(node, "optional"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Structure {
+    pub name: XmlStr,
+    pub structextends: Vec<&'static str>,
+    pub members: Vec<StructureMember>,
+}
+
+impl Structure {
+    fn from_node(node: Node, api: &str) -> Structure {
+        Structure {
+            name: attribute(node, "name").unwrap(),
+            structextends: attribute_comma_separated(node, "structextends"),
+            members: node
+                .children()
+                .filter(|node| node.has_tag_name("member"))
+                .filter(|node| api_matches(node, api))
+                .map(StructureMember::from_node)
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Constant {
+    pub ty: XmlStr,
+    pub value: XmlStr,
+    pub name: XmlStr,
+}
+
+impl Constant {
+    fn from_node(node: Node) -> Constant {
+        Constant {
+            ty: attribute(node, "type").unwrap(),
+            value: attribute(node, "value").unwrap(),
+            name: attribute(node, "name").unwrap(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct EnumValue {
+    pub value: XmlStr,
+    pub name: XmlStr,
+}
+
+impl EnumValue {
+    fn from_node(node: Node) -> EnumValue {
+        EnumValue {
+            value: attribute(node, "value").unwrap(),
+            name: attribute(node, "name").unwrap(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Enum {
+    pub name: XmlStr,
+    pub values: Vec<EnumValue>,
+    pub aliases: Vec<Alias>,
+}
+
+impl Enum {
+    fn from_node(node: Node, api: &str) -> Enum {
+        let mut value = Enum {
+            name: attribute(node, "name").unwrap(),
+            values: Vec::new(),
+            aliases: Vec::new(),
+        };
+
+        for variant in node
+            .children()
+            .filter(|node| node.has_tag_name("enum"))
+            .filter(|node| api_matches(node, api))
+        {
+            if variant.has_attribute("alias") {
+                value.aliases.push(Alias::from_node(variant));
+            } else {
+                value.values.push(EnumValue::from_node(variant));
+            }
+        }
+
+        value
+    }
+}
+
+#[derive(Debug)]
+pub struct BitMaskBit {
+    pub bitpos: XmlStr,
+    pub name: XmlStr,
+}
+
+impl BitMaskBit {
+    fn from_node(node: Node) -> BitMaskBit {
+        BitMaskBit {
+            bitpos: attribute(node, "bitpos").unwrap(),
+            name: attribute(node, "name").unwrap(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct BitMask {
+    pub name: XmlStr,
+    pub bits: Vec<BitMaskBit>,
+    /// Some bitmask variants represent literal values instead of specific
+    /// individual bits, e.g. a combination of bits, or no bits at all. A good
+    /// example for this is `VkCullModeFlagBits::FRONT_AND_BACK`.
+    pub values: Vec<EnumValue>,
+    pub aliases: Vec<Alias>,
+}
+
+impl BitMask {
+    fn from_node(node: Node, api: &str) -> BitMask {
+        let mut value = BitMask {
+            name: attribute(node, "name").unwrap(),
+            bits: Vec::new(),
+            values: Vec::new(),
+            aliases: Vec::new(),
+        };
+
+        for variant in node
+            .children()
+            .filter(|node| node.has_tag_name("enum"))
+            .filter(|node| api_matches(node, api))
+        {
+            if variant.has_attribute("alias") {
+                value.aliases.push(Alias::from_node(variant));
+            } else if variant.has_attribute("value") {
+                value.values.push(EnumValue::from_node(variant));
+            } else {
+                value.bits.push(BitMaskBit::from_node(variant));
+            }
+        }
+
+        value
+    }
+}
+
+#[derive(Debug)]
+pub struct CommandParam {
+    pub name: XmlStr,
+    pub c_declaration: String,
+    pub len: Option<XmlStr>,
+    pub altlen: Option<XmlStr>,
+    pub optional: Vec<&'static str>,
+}
+
+impl CommandParam {
+    fn from_node(node: Node) -> CommandParam {
+        CommandParam {
+            name: child_text(node, "name").unwrap(),
+            c_declaration: descendant_text(node),
+            len: attribute(node, "len"),
+            altlen: attribute(node, "altlen"),
+            optional: attribute_comma_separated(node, "optional"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Command {
+    pub return_type: XmlStr,
+    pub name: XmlStr,
+    pub params: Vec<CommandParam>,
+}
+
+impl Command {
+    fn from_node(node: Node, api: &str) -> Command {
+        let proto = node
+            .children()
+            .find(|child| child.has_tag_name("proto"))
+            .filter(|node| api_matches(node, api))
+            .unwrap();
+        Command {
+            return_type: child_text(proto, "type").unwrap(),
+            name: child_text(proto, "name").unwrap(),
+            params: node
+                .children()
+                .filter(|child| child.has_tag_name("param"))
+                .filter(|node| api_matches(node, api))
+                .map(CommandParam::from_node)
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct RequireConstant {
+    pub name: XmlStr,
+    /// `Some` indicates a new constant being defined here.
+    pub value: Option<XmlStr>,
+}
+
+impl RequireConstant {
+    fn from_node(node: Node) -> RequireConstant {
+        RequireConstant {
+            name: attribute(node, "name").unwrap(),
+            value: attribute(node, "value"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct RequireEnumVariant {
+    pub name: XmlStr,
+    pub offset: u8,
+    pub extends: XmlStr,
+}
+
+impl RequireEnumVariant {
+    fn from_node(node: Node) -> RequireEnumVariant {
+        RequireEnumVariant {
+            name: attribute(node, "name").unwrap(),
+            offset: attribute(node, "offset").unwrap().parse().unwrap(),
+            extends: attribute(node, "extends").unwrap(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct RequireBitPos {
+    pub name: XmlStr,
+    pub bitpos: u8,
+    pub extends: XmlStr,
+}
+
+impl RequireBitPos {
+    fn from_node(node: Node) -> RequireBitPos {
+        RequireBitPos {
+            name: attribute(node, "name").unwrap(),
+            bitpos: attribute(node, "bitpos").unwrap().parse().unwrap(),
+            extends: attribute(node, "extends").unwrap(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct RequireType {
+    pub name: XmlStr,
+}
+
+impl RequireType {
+    fn from_node(node: Node) -> RequireType {
+        RequireType {
+            name: attribute(node, "name").unwrap(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct RequireCommand {
+    pub name: XmlStr,
+}
+
+impl RequireCommand {
+    fn from_node(node: Node) -> RequireCommand {
+        RequireCommand {
+            name: attribute(node, "name").unwrap(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Version {
+    pub major: u32,
+    pub minor: u32,
+}
+
+impl Version {
+    fn from_str(s: &str) -> Option<Version> {
+        let major_minor = s.strip_prefix("VK_VERSION_")?;
+
+        let mut iter = major_minor.split('_').flat_map(str::parse);
+        let (Some(major), Some(minor), None) = (iter.next(), iter.next(), iter.next()) else {
+            return None;
+        };
+
+        Some(Version { major, minor })
+    }
+}
+
+#[derive(Debug)]
+pub enum Depends {
+    Version(Version),
+    Extension(&'static str),
+}
+
+impl Depends {
+    fn from_str(s: &'static str) -> Depends {
+        Version::from_str(s).map_or_else(|| Depends::Extension(s), Depends::Version)
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Require {
+    pub depends: Vec<Depends>,
+    pub enum_variants: Vec<RequireEnumVariant>,
+    pub bitpositions: Vec<RequireBitPos>,
+    pub constants: Vec<RequireConstant>,
+    pub types: Vec<RequireType>,
+    pub commands: Vec<RequireCommand>,
+}
+
+impl Require {
+    fn from_node(node: Node, api: &str) -> Require {
+        let mut value = Require {
+            depends: attribute(node, "depends")
+                .map(|value| (value.unwrap_borrowed().split(',').map(Depends::from_str)).collect())
+                .unwrap_or_default(),
+            ..Default::default()
+        };
+
+        for child in node.children().filter(|node| api_matches(node, api)) {
+            match child.tag_name().name() {
+                "enum" => {
+                    if child.has_attribute("offset") {
+                        value
+                            .enum_variants
+                            .push(RequireEnumVariant::from_node(child));
+                    } else if child.has_attribute("bitpos") {
+                        value.bitpositions.push(RequireBitPos::from_node(child));
+                    } else {
+                        value.constants.push(RequireConstant::from_node(child));
+                    }
+                }
+                "type" => value.types.push(RequireType::from_node(child)),
+                "command" => value.commands.push(RequireCommand::from_node(child)),
+                _ => (),
+            }
+        }
+
+        value
+    }
+}
+
+#[derive(Debug)]
+pub struct Feature {
+    pub name: XmlStr,
+    pub version: Version,
+    pub requires: Vec<Require>,
+}
+
+impl Feature {
+    fn from_node(node: Node, api: &str) -> Feature {
+        let name = attribute(node, "name").unwrap();
+
+        Feature {
+            version: Version::from_str(&name).unwrap(),
+            name,
+            requires: node
+                .children()
+                .filter(|child| child.has_tag_name("require"))
+                .filter(|node| api_matches(node, api))
+                .map(|child| Require::from_node(child, api))
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Extension {
+    pub name: XmlStr,
+    pub number: Option<u32>,
+    pub ty: Option<XmlStr>,
+    pub requires: Vec<Require>,
+}
+
+impl Extension {
+    fn from_node(node: Node, api: &str) -> Extension {
+        Extension {
+            name: attribute(node, "name").unwrap(),
+            number: attribute(node, "number").map(|value| value.parse().unwrap()),
+            ty: attribute(node, "type"),
+            requires: node
+                .children()
+                .filter(|child| child.has_tag_name("require"))
+                .filter(|node| api_matches(node, api))
+                .map(|child| Require::from_node(child, api))
+                .collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vk_xml() {
+        let xml_input = Box::leak(
+            std::fs::read_to_string("../generator/Vulkan-Headers/registry/vk.xml")
+                .unwrap()
+                .into_boxed_str(),
+        );
+
+        Registry::parse(xml_input, "vulkan");
+    }
+
+    #[test]
+    fn video_xml() {
+        let xml_input = Box::leak(
+            std::fs::read_to_string("../generator/Vulkan-Headers/registry/video.xml")
+                .unwrap()
+                .into_boxed_str(),
+        );
+
+        Registry::parse(xml_input, "vulkan");
+    }
+}

--- a/analysis/src/xml.rs
+++ b/analysis/src/xml.rs
@@ -1,4 +1,5 @@
-use roxmltree::StringStorage;
+use crate::cdecl::{CDecl, CDeclMode, CTok, CType};
+use roxmltree::{NodeType, StringStorage};
 use std::{borrow::Cow, fmt::Write};
 use tracing::{debug, info_span, trace};
 
@@ -59,17 +60,6 @@ fn child_text(node: Node, name: &str) -> Option<XmlStr> {
     })
 }
 
-/// Retrieves the text of all of `node`'s descendants, concatenated.
-/// Anything within a `<comment>` element will be ignored.
-fn descendant_text(node: Node) -> String {
-    node.descendants()
-        .filter(Node::is_text)
-        // Ignore any text within a <comment> element.
-        .filter(|node| !node.ancestors().any(|node| node.has_tag_name("comment")))
-        .map(|node| node.text().unwrap())
-        .collect::<String>()
-}
-
 /// Returns [`true`] when the `node`'s "api" attribute matches the `expected` API.
 fn api_matches(node: &Node, expected: &str) -> bool {
     node.attribute("api")
@@ -85,6 +75,65 @@ fn node_span_field(node: &Node) -> String {
     }
 
     output + ">"
+}
+
+impl CDecl<'static> {
+    fn from_xml(mode: CDeclMode, children: roxmltree::Children<'_, 'static>) -> CDecl<'static> {
+        let mut c_tokens = vec![];
+        for child in children {
+            let text = || make_xml_str(child.text_storage().unwrap().clone()).unwrap_borrowed();
+            match child.node_type() {
+                NodeType::Text => {
+                    CTok::lex_into(text(), &mut c_tokens).unwrap();
+                }
+                NodeType::Element => {
+                    assert_eq!(child.attributes().len(), 0);
+                    let text = || {
+                        assert_eq!(child.children().count(), 1);
+                        text()
+                    };
+                    c_tokens.push(match child.tag_name().name() {
+                        "comment" => continue,
+                        "type" => CTok::TypeName(text()),
+                        "enum" => CTok::ValueName(text()),
+                        "name" => CTok::DeclName(text()),
+                        tag => unreachable!("unexpected `<{tag}>` in C declaration"),
+                    })
+                }
+                NodeType::Root | NodeType::PI | NodeType::Comment => unreachable!(),
+            }
+        }
+
+        c_tokens.retain_mut(|tok| {
+            if let CTok::StrayIdent(name) = tok {
+                match &name[..] {
+                    // HACK(eddyb) work around `video.xml` spec bug (missing `<enum>`).
+                    "STD_VIDEO_H264_MAX_NUM_LIST_REF" | "STD_VIDEO_H265_MAX_NUM_LIST_REF" => {
+                        *tok = CTok::ValueName(name);
+                    }
+
+                    // HACK(eddyb) work around `vk.xml` spec bug (missing `<type>`).
+                    "VkBool32" | "PFN_vkVoidFunction" => {
+                        *tok = CTok::TypeName(name);
+                    }
+
+                    _ => {}
+                }
+            }
+
+            match tok {
+                // HACK(eddyb) ideally we'd expand this to something using the
+                // C++11/C23 `[[...]]` attribute syntax, but that'd need support
+                // in `cdecl`, and it's redundant since all function pointers
+                // equally get it, so we can just remove it here.
+                CTok::StrayIdent("VKAPI_PTR") => false,
+
+                _ => true,
+            }
+        });
+
+        CDecl::parse(mode, &c_tokens).unwrap()
+    }
 }
 
 /// Raw representation of Vulkan XML files (`vk.xml`, `video.xml`).
@@ -357,16 +406,14 @@ impl EnumType {
 
 #[derive(Debug)]
 pub struct FuncPointer {
-    pub name: XmlStr,
-    pub c_declaration: String,
+    pub c_decl: CDecl<'static>,
     pub requires: Option<XmlStr>,
 }
 
 impl FuncPointer {
     fn from_node(node: Node) -> FuncPointer {
         FuncPointer {
-            name: child_text(node, "name").unwrap(),
-            c_declaration: descendant_text(node),
+            c_decl: CDecl::from_xml(CDeclMode::TypeDef, node.children()),
             requires: attribute(node, "requires"),
         }
     }
@@ -374,8 +421,7 @@ impl FuncPointer {
 
 #[derive(Debug)]
 pub struct StructureMember {
-    pub name: XmlStr,
-    pub c_declaration: String,
+    pub c_decl: CDecl<'static>,
     pub values: Option<XmlStr>,
     pub len: Vec<&'static str>,
     pub altlen: Option<XmlStr>,
@@ -385,8 +431,7 @@ pub struct StructureMember {
 impl StructureMember {
     fn from_node(node: Node) -> StructureMember {
         StructureMember {
-            name: child_text(node, "name").unwrap(),
-            c_declaration: descendant_text(node),
+            c_decl: CDecl::from_xml(CDeclMode::StructMember, node.children()),
             values: attribute(node, "values"),
             len: attribute_comma_separated(node, "len"),
             altlen: attribute(node, "altlen"),
@@ -535,8 +580,7 @@ impl BitMask {
 
 #[derive(Debug)]
 pub struct CommandParam {
-    pub name: XmlStr,
-    pub c_declaration: String,
+    pub c_decl: CDecl<'static>,
     pub len: Option<XmlStr>,
     pub altlen: Option<XmlStr>,
     pub optional: Vec<&'static str>,
@@ -545,8 +589,7 @@ pub struct CommandParam {
 impl CommandParam {
     fn from_node(node: Node) -> CommandParam {
         CommandParam {
-            name: child_text(node, "name").unwrap(),
-            c_declaration: descendant_text(node),
+            c_decl: CDecl::from_xml(CDeclMode::FuncParam, node.children()),
             len: attribute(node, "len"),
             altlen: attribute(node, "altlen"),
             optional: attribute_comma_separated(node, "optional"),
@@ -556,7 +599,7 @@ impl CommandParam {
 
 #[derive(Debug)]
 pub struct Command {
-    pub return_type: XmlStr,
+    pub return_type: Option<CType<'static>>,
     pub name: XmlStr,
     pub params: Vec<CommandParam>,
 }
@@ -568,9 +611,11 @@ impl Command {
             .find(|child| child.has_tag_name("proto"))
             .filter(|node| api_matches(node, api))
             .unwrap();
+        // FIXME(eddyb) `CDeclMode::StructMember` should work but isn't accurate.
+        let proto_cdecl = CDecl::from_xml(CDeclMode::StructMember, proto.children());
         Command {
-            return_type: child_text(proto, "type").unwrap(),
-            name: child_text(proto, "name").unwrap(),
+            return_type: Some(proto_cdecl.ty).filter(|ty| *ty != CType::VOID),
+            name: proto_cdecl.name.into(),
             params: node
                 .children()
                 .filter(|child| child.has_tag_name("param"))

--- a/generator-rewrite/Cargo.toml
+++ b/generator-rewrite/Cargo.toml
@@ -6,3 +6,5 @@ publish = false
 
 [dependencies]
 analysis = { path = "../analysis" }
+tracing = "0.1"
+tracing-subscriber = "0.3"

--- a/generator-rewrite/src/main.rs
+++ b/generator-rewrite/src/main.rs
@@ -4,4 +4,7 @@ fn main() {
     tracing_subscriber::fmt::init();
     let _analysis = Analysis::new("generator/Vulkan-Headers");
     // dbg!(_analysis);
+    if true {
+        _analysis.dump_as_pseudo_rust();
+    }
 }

--- a/generator-rewrite/src/main.rs
+++ b/generator-rewrite/src/main.rs
@@ -1,5 +1,7 @@
 use analysis::Analysis;
 
 fn main() {
+    tracing_subscriber::fmt::init();
     let _analysis = Analysis::new("generator/Vulkan-Headers");
+    // dbg!(_analysis);
 }


### PR DESCRIPTION
For some background, see https://github.com/ash-rs/ash/pull/745#issuecomment-1913181282.

Example dump output (from second commit): https://gist.github.com/eddyb/5ae0247468892ea7dd2a136ed3afa869.

I haven't spent much time trying to tweak the exact `CType` AST etc. - I assume that `ash` would want to also account for differences between C and Rust and other such things that I'm not familiar with.

So the goal here was to be lossless: all the information is included, in an easily-traversable form.